### PR TITLE
Add namespaces to Jena RDF export

### DIFF
--- a/src/plaza/rdf/implementations/jena.clj
+++ b/src/plaza/rdf/implementations/jena.clj
@@ -272,7 +272,14 @@
                                      (.read mod stream *rdf-ns* format))))
                  model))
   (output-string  [model writer format]
-                  (critical-read model (fn [] (.write mod writer (parse-format format)))))
+                  (critical-read model (fn [] 
+                                         (try
+                                           (let [existing-prefixes (.getNsPrefixMap mod)
+                                                 new-map @*rdf-ns-table*
+                                                 new-prefixes (zipmap (map name (keys new-map)) (vals new-map))]
+                                             (.setNsPrefixes mod (merge new-prefixes existing-prefixes)))
+                                           (catch Exception e (.printStackTrace e)))
+                                         (.write mod writer (parse-format format)))))
   (output-string  [model format]
                   (output-string model *out* format))
   (query [model query] (model-query-fn model query (str (build-query *sparql-framework* query))))


### PR DESCRIPTION
Don't apply this alone - it breaks the tests for some reason - ints turn into longs - but I am not able to figure out why!

2012-07-02 09:57:01 [main] INFO org.openrdf.rio.RDFParserRegistry: Registered service class org.openrdf.rio.turtle.TurtleParserFactory

FAIL in (test-make-typed-literal-sesame) (core_test_sesame.clj:93)
expected: (= (to-string p1) "\"2\"^^http://www.w3.org/2001/XMLSchema#int")
  actual: (not (= "\"2\"^^http://www.w3.org/2001/XMLSchema#long" "\"2\"^^http://www.w3.org/2001/XMLSchema#int"))

FAIL in (test-triple-object-sesame) (core_test_sesame.clj:135)
expected: (= (to-string p4) "\"2\"^^http://www.w3.org/2001/XMLSchema#int")
  actual: (not (= "\"2\"^^http://www.w3.org/2001/XMLSchema#long" "\"2\"^^http://www.w3.org/2001/XMLSchema#int"))

Testing plaza.rdf.implementations.jena-test

Testing plaza.rdf.implementations.sesame-test
2012-07-02 09:57:01 [main] INFO org.openrdf.query.parser.QueryParserRegistry: Registered service class org.openrdf.query.parser.serql.SeRQLParserFactory
2012-07-02 09:57:01 [main] INFO org.openrdf.query.parser.QueryParserRegistry: Registered service class org.openrdf.query.parser.sparql.SPARQLParserFactory
handshake...

FAIL in (test-sesame-typed-literal) (sesame_test.clj:82)
expected: (= "\"2\"^^http://www.w3.org/2001/XMLSchema#int" (to-string res))
  actual: (not (= "\"2\"^^http://www.w3.org/2001/XMLSchema#int" "\"2\"^^http://www.w3.org/2001/XMLSchema#long"))

FAIL in (test-sesame-typed-literal) (sesame_test.clj:87)
expected: (= (resource-id res) "\"2\"^^http://www.w3.org/2001/XMLSchema#int")
  actual: (not (= "\"2\"^^http://www.w3.org/2001/XMLSchema#long" "\"2\"^^http://www.w3.org/2001/XMLSchema#int"))

FAIL in (test-sesame-typed-literal) (sesame_test.clj:90)
expected: (= (literal-datatype-uri res) "http://www.w3.org/2001/XMLSchema#int")
  actual: (not (= "http://www.w3.org/2001/XMLSchema#long" "http://www.w3.org/2001/XMLSchema#int"))

Testing plaza.rdf.predicates-test

Testing plaza.rdf.schemas-test

Testing plaza.rdf.sparql-test
2012-07-02 09:57:03 [main] WARN com.hp.hpl.jena.sparql.expr.NodeValue: Both lang tag and datatype defined (lexcial form '2')
2012-07-02 09:57:04 [main] WARN com.hp.hpl.jena.sparql.expr.NodeValue: Both lang tag and datatype defined (lexcial form '3')

FAIL in (test-build-filters-2) (sparql_test.clj:130)
expected: (= gt "( ?x > \"3\"^^xsd:int )")
  actual: (not (= "( ?x > \"3\"^^xsd:long )" "( ?x > \"3\"^^xsd:int )"))
2012-07-02 09:57:04 [main] WARN com.hp.hpl.jena.sparql.expr.NodeValue: Both lang tag and datatype defined (lexcial form '2005-01-01T00:00:00Z')

Testing plaza.rdf.sparql-test-sesame
2012-07-02 09:57:04 [main] WARN com.hp.hpl.jena.sparql.expr.NodeValue: Both lang tag and datatype defined (lexcial form '2')
2012-07-02 09:57:04 [main] WARN com.hp.hpl.jena.sparql.expr.NodeValue: Both lang tag and datatype defined (lexcial form '3')

FAIL in (test-build-filters-2) (sparql_test_sesame.clj:129)
expected: (= gt "( ?x > \"3\"^^xsd:int )")
  actual: (not (= "( ?x > \"3\"^^xsd:long )" "( ?x > \"3\"^^xsd:int )"))
2012-07-02 09:57:04 [main] WARN com.hp.hpl.jena.sparql.expr.NodeValue: Both lang tag and datatype defined (lexcial form '2005-01-01T00:00:00Z')
